### PR TITLE
add focus to our list of custom assertions

### DIFF
--- a/lib/rules/chai-expect-checker.js
+++ b/lib/rules/chai-expect-checker.js
@@ -96,6 +96,7 @@ const accessorTypes = {
   'invalidModel': 'property',
   'ngHidden': 'property',
   'modelError': 'function',
+  'focus': 'property',
 
   // custom content section element assertions
   'sectionPlaceholder': 'function',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-console-saas-rules",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Custom ESLint rules for console saas web",
   "keywords": [
     "eslint",


### PR DESCRIPTION
I noticed eslint was throwing an error due to our new custom "focus" assertion.