### PR TITLE
Add include to list of accessors

### DIFF
--- a/lib/rules/chai-expect-checker.js
+++ b/lib/rules/chai-expect-checker.js
@@ -56,6 +56,7 @@ const accessorTypes = {
   'extensible': 'property',
   'sealed': 'property',
   'frozen': 'property',
+  'include': 'function',
 
   // chai-as-promised
   'fulfilled': 'property',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-console-saas-rules",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Custom ESLint rules for console saas web",
   "keywords": [
     "eslint",


### PR DESCRIPTION
"include" was used in client/src/features/accounting/invoice/common/ui/invoiceItemsInputTable/invoiceItemsInputTable.component.test.js:39 and currently throws an eslint warning